### PR TITLE
handle nicknames

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -84,7 +84,28 @@ def get_link(value):
         return "Unknown"
 
 def format_item(item):
+    nickname_map = { # some nicknames/variations seen around the subreddit.
+        "banana": "gros michel",
+        "oops! all sixes": "oops! all 6s",
+        "oops, all sixes": "oops! all 6s",
+        "oops all sixes": "oops! all 6s",
+        "eight ball": "8 ball",
+        "cloud nine": "cloud 9",
+        "bean": "turtle bean",
+        "jonkler": "joker",
+        "jimbo": "joker",
+        "cat": "lucky cat",
+        "sock": "sock and buskin",
+        "sock n buskin": "sock and buskin",
+        "stencil": "joker stencil",
+        "pants": "spare trousers",
+        "spare pants": "spare trousers"
+    }
     item = item.lower().strip()
     if item.startswith("the "):
         item = item[4:]
+    if item.endswith(" joker"):
+        item = item[:-6]
+    if item in nickname_map:
+        item = nickname_map[item]
     return item

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,3 +25,9 @@ def test_build_reply_with_items():
     assert ("[Ankh](http://localhost:8080/Spectral_Cards) (Spectral Card)" in build_reply_with_items(["ankh"])) is True
     assert ("[The Arm](http://localhost:8080/Blinds_and_Antes) (Blind)" in build_reply_with_items(["arm"])) is True
     assert ("[Eris](http://localhost:8080/Planet_Cards) (Planet Card)" in build_reply_with_items(["eris"])) is True
+    assert ("[Gros Michel](http://localhost:8080/Gros_Michel) (Common Joker)" in build_reply_with_items(["banana"])) is True
+    assert ("[Wee Joker](http://localhost:8080/Wee_Joker) (Rare Joker)" in build_reply_with_items(["wee"])) is True
+    assert ("[Joker Stencil](http://localhost:8080/Joker_Stencil) (Uncommon Joker)" in build_reply_with_items(["stencil"])) is True
+    assert ("[Turtle Bean](http://localhost:8080/Turtle_Bean) (Uncommon Joker)" in build_reply_with_items(["bean"])) is True
+    assert ("[Wily Joker](http://localhost:8080/Wily_Joker) (Common Joker)" in build_reply_with_items(["wily"])) is True
+    assert ("[Cloud 9](http://localhost:8080/Cloud_9) (Uncommon Joker)" in build_reply_with_items(["cloud nine"])) is True


### PR DESCRIPTION
- strip " joker" suffixes from inputs, similar to how we trim "the " prefixes
- hardcode a small list of common nicknames/equivalents to make the matching a bit more robust.